### PR TITLE
Traverse method for transient_hdr_film and nloscapturemeter

### DIFF
--- a/mitransient/films/transient_hdr_film.py
+++ b/mitransient/films/transient_hdr_film.py
@@ -43,6 +43,13 @@ class TransientHDRFilm(mi.Film):
             channel_use_weights=channel_use_weights,
             rfilter=rfilter)
 
+    def traverse(self, callback):
+        # TODO: all the parameters are set as NonDifferentiable by default
+        super().traverse(callback)
+        callback.put_parameter('temporal_bins', self.temporal_bins, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter('bin_width_opl', self.bin_width_opl, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter('start_opl', self.start_opl, mi.ParamFlags.NonDifferentiable)
+
 
 mi.register_film("transient_hdr_film",
                  lambda props: TransientHDRFilm(props))

--- a/mitransient/sensors/nloscapturemeter.py
+++ b/mitransient/sensors/nloscapturemeter.py
@@ -165,8 +165,17 @@ class NLOSCaptureMeter(mi.Sensor):
             self.laser_target - self.laser_origin) * self.IOR_BASE
 
     def traverse(self, callback: mi.TraversalCallback):
-        # TODO implement traverse (use callback for params and objects)
+        # TODO: all the parameters are set as NonDifferentiable by default
         super().traverse(callback)
+        callback.put_object("emitter", self.emitter, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("needs_sample_3", self.needs_sample_3, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("account_first_and_last_bounces", self.account_first_and_last_bounces, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("is_confocal", self.is_confocal, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("film_size", self.film_size, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("laser_origin", self.laser_origin, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("laser_lookat", self.laser_lookat, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("laser_target", self.laser_target, mi.ParamFlags.NonDifferentiable)
+        callback.put_parameter("laser_bounce_opl", self.laser_bounce_opl, mi.ParamFlags.NonDifferentiable)
 
     def sample_ray_differential(
             self, time: mi.Float,


### PR DESCRIPTION
This PR overrides the method `traverse()` for transient_hdr_film and nloscapturemeter so that the fields of those classes can be seen when calling `params = mi.traverse(scene)`.