### PR TITLE
fix: fixing error in transient_pbrvolpath

### DIFF
--- a/mitransient/integrators/transient_prbvolpath.py
+++ b/mitransient/integrators/transient_prbvolpath.py
@@ -239,7 +239,7 @@ class TransientPRBVolpathIntegrator(TransientADIntegrator):
                 intersect = active_surface & needs_intersection
                 si[intersect] = scene.ray_intersect(ray, intersect)
 
-                distance[intersect] += si.t * η
+                distance[active_surface] += si.t * η
 
                 # ----------------- Intersection with emitters -----------------
 


### PR DESCRIPTION
I found a problem in the way to manage distances when an object is placed inside a medium. The distance to the light was completely added, but the distance to the sensor was not properly added. Specifically, the distance to the object within the medium was missing. This correction fixes the problem.