### PR TITLE
Update cbox_diffuse_freq.xml

### DIFF
--- a/examples/transient/cornell-box/cbox_diffuse_freq.xml
+++ b/examples/transient/cornell-box/cbox_diffuse_freq.xml
@@ -34,7 +34,7 @@
             <float name="wl_mean" value="100"/>
             <float name="wl_sigma" value="100"/>
             <integer name="temporal_bins" value="4000"/>
-            <float name="delta_t" value="0.003"/>
+            <float name="bin_width_opl" value="0.003"/>
             <float name="start_opl" value="0"/>
             <rfilter type="box">
               <!-- <float name="stddev" value="1.0"/> -->


### PR DESCRIPTION
## Small Fix
- "delta_t" is not supported in latest version
- run the xml can get error below
```pyrhon
RuntimeError: ​[xml.cpp:1103] Error while loading "e:\linyaodong\mitransient\examples\transient\cornell-box\cbox_diffuse_freq.xml" (near line 32, col 2): unreferenced property "["delta_t"]" in film plugin of type "phasor_hdr_film
```
